### PR TITLE
Fix documentation to use the correct variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The pod will return the name of the admin client that you can then pass back to 
 (k/get-metadata admin-client)
 
 ;; e.g to list all the topics
-(-> (k/get-metadata admin-config)
+(-> (k/get-metadata admin-client)
     :Topics
     keys)
 


### PR DESCRIPTION
get-metadata expects admin-client which is a string, but admin-config map was passed instead. Without this change, you'll end up with a Unmarshalling error from golang.